### PR TITLE
WIP: Impl legacy feature

### DIFF
--- a/chain-db/src/lib.rs
+++ b/chain-db/src/lib.rs
@@ -261,7 +261,7 @@ impl ChainDB {
             .map(|(key, val)| (key.to_vec(), val.to_vec()))
             .collect::<Vec<_>>();
         if found.is_empty() {
-            return Err(Box::new(io::Error::new(io::ErrorKind::NotFound, "bock not found")));
+            return Err(Box::new(io::Error::new(io::ErrorKind::NotFound, "block not found")));
         }
         if found.len() > 1 {
             eprintln!("multiple blocks found for same number: {}", num);

--- a/keys/src/signature.rs
+++ b/keys/src/signature.rs
@@ -100,6 +100,10 @@ impl<'a> TryFrom<&'a [u8]> for Signature {
         if v.len() == 65 {
             let mut inner = [0u8; 65];
             (&mut inner[..]).copy_from_slice(v);
+            // NOTE: 0x2fe5b7a5610aa9dc081574b0451af82ac586ac0a67e2da2a100a5923c862e357
+            if inner[64] >= 27 {
+                inner[64] -= 27;
+            }
             Ok(Signature(inner))
         } else {
             Err(Error::InvalidSignature)


### PR DESCRIPTION
The old blocks and transactions of mainnet are very error some.

Like:

- wrong protobuf format: many, already fixed by proto2. Still vulnerable for java-tron.
- invalid signature (with +27 rec_id fix😅): 2fe5b7a5610aa9dc081574b0451af82ac586ac0a67e2da2a100a5923c862e357

This PR is to fix all these, to make OpenTron sync and handle mainnet chain-db.
